### PR TITLE
Clamped values to avoid numerical instabilities

### DIFF
--- a/kumaraswamy.py
+++ b/kumaraswamy.py
@@ -99,8 +99,11 @@ class Kumaraswamy(TransformedDistribution):
         # U ~ Uniform(cdf(k0), cdf(k1)) 
         # K = F^-1(U)
         #  simulates K over the truncated support (k0,k1)
-        x = Uniform(self.cdf(torch.full_like(self.a, k0)), 
-                    self.cdf(torch.full_like(self.b, k1))).rsample(sample_shape)
+        
+        l_b = torch.clamp(self.cdf(torch.full_like(self.a, k0)), min=EPS)
+        h_b = torch.clamp(self.cdf(torch.full_like(self.b, k1)), max=(1 - EPS*10))
+        
+        x = Uniform(l_b, h_b).rsample(sample_shape)
         for transform in self.transforms:
             x = transform(x)
         return x

--- a/stretchrectify.py
+++ b/stretchrectify.py
@@ -61,13 +61,13 @@ class StretchedAndRectifiedDistribution(torch.distributions.Distribution):
         zeros = torch.zeros_like(value)
         log_p = torch.where(value == zeros,
                             #torch.log(self.base.cdf((value - self.loc) / self.scale)),
-                            torch.log(self.stretched.cdf(zeros)),
+                            torch.log(torch.clamp(self.stretched.cdf(zeros), min=EPS)),
                             self.stretched.log_prob(value))
         
         # log_q(x==1) = 1 - cdf_p(1)
         ones = torch.ones_like(value)
         log_p = torch.where(value == ones,
-                            torch.log(1 - self.stretched.cdf(ones)),
+                            torch.log(torch.clamp(1 - self.stretched.cdf(ones), min=EPS)),
                             log_p)
         
         return log_p


### PR DESCRIPTION
Changes:

1. For some parameter values, example: `(a, b) = (0.0708, 3.5888)`, `log_prob` of HardKumaraswamy is `NaN` because of non-positive values in the log function

2. In `rsample_truncated`, we need to sample from open interval `(0, 1)`.  I use `1 - EPS*10`  as the max value for clamp because pytorch rounds off `1.0 - EPS` to `1.0`