### PR TITLE
Change the Concrete KL to logit space to avoid underflow (fixed)

### DIFF
--- a/probabll/distributions/concrete.py
+++ b/probabll/distributions/concrete.py
@@ -28,7 +28,7 @@ def kl_concrete_concrete(p, q, n_samples=1):
     """
     KL is estimated for the logits of the concrete distribution to avoid underflow.
     """
-    x_logit = p.base_dist.rsample(torch.Size([n_samples]))
+    x_logit = p.base_dist.sample(torch.Size([n_samples]))
     return (p.base_dist.log_prob(x_logit) - q.base_dist.log_prob(x_logit)).mean(0)
 
 

--- a/probabll/distributions/concrete.py
+++ b/probabll/distributions/concrete.py
@@ -28,7 +28,7 @@ def kl_concrete_concrete(p, q, n_samples=1):
     """
     KL is estimated for the logits of the concrete distribution to avoid underflow.
     """
-    x_logit = p.base_dist.sample(torch.Size([n_samples]))
+    x_logit = p.base_dist.rsample(torch.Size([n_samples]))
     return (p.base_dist.log_prob(x_logit) - q.base_dist.log_prob(x_logit)).mean(0)
 
 

--- a/probabll/distributions/concrete.py
+++ b/probabll/distributions/concrete.py
@@ -22,10 +22,14 @@ class BinaryConcrete(torch.distributions.relaxed_bernoulli.RelaxedBernoulli):
                            self.cdf(torch.full_like(self.logits, k1))).rsample(sample_shape)
         x = (uniforms.log() - (-uniforms).log1p() + probs.log() - (-probs).log1p()) / self.temperature
         return torch.sigmoid(x)
-    
+
+
 def kl_concrete_concrete(p, q, n_samples=1):
-    x = p.sample(sample_shape=torch.Size([n_samples]))
-    return (p.log_prob(x) - q.log_prob(x)).mean(0)
+    """
+    KL is estimated for the logits of the concrete distribution to avoid underflow.
+    """
+    x_logit = p.base_dist.rsample(torch.Size([n_samples]))
+    return (p.base_dist.log_prob(x_logit) - q.base_dist.log_prob(x_logit)).mean(0)
 
 
 @register_kl(BinaryConcrete, BinaryConcrete)


### PR DESCRIPTION
Madison et al. recommend using the logits of the concrete distribution as stochastic node, to avoid numerical underflow in the KL. Pytorch now supports this, so we only need to change the KL estimation to use the base LogitRelaxedBernoulli distribution instead of the RelaxedBernoulli.

Small fix from PR #3: use sample instead of rsample.